### PR TITLE
fix(docs): add double asterisk to avoid tag issues

### DIFF
--- a/doc/base16-pro-max.nvim.txt
+++ b/doc/base16-pro-max.nvim.txt
@@ -65,7 +65,7 @@ Types                                                     *base16-pro-max.types*
 Base16ProMax.Config                                        *Base16ProMax.Config*
 
     Fields: ~
-        {colors?}            (table<Base16ProMax.Group.Raw,string>)                                                          Colors to override
+        {colors}             (table<Base16ProMax.Group.Raw,string>)                                                          Colors to override
         {styles?}            (Base16ProMax.Config.Styles)                                                                    Styles to override
         {highlight_groups?}  (Base16ProMax.Config.HighlightGroups.Table|Base16ProMax.Config.HighlightGroups.Function)        Additional highlight groups to set
         {before_highlight?}  (fun(group:string,opts:vim.api.keyset.highlight,c:table<Base16ProMax.Group.Alias,string>):nil)  Callback to run before setting highlight groups
@@ -384,13 +384,13 @@ Note that `colors` in the config table is compulsary and must be provided.
 
 All boolean options are `false` and opt-in by default.
 
- - colors: *Required* - the 16 Base 16 hex codes
- - highlight_groups: *Optional* - additional highlight groups to set
- - before_highlight: *Optional* - callback to run before setting highlight groups
- - styles: *Optional* - styling options
- - plugins: *Optional* - enable/disable plugins
- - setup_globals: *Optional* - setup vim.g globals
- - color_groups: *Optional* - semantic color groups
+ - `colors`: **Required** - the 16 Base 16 hex codes
+ - `highlight_groups`: **Optional** - additional highlight groups to set
+ - `before_highlight`: **Optional** - callback to run before setting highlight groups
+ - `styles`: **Optional** - styling options
+ - `plugins`: **Optional** - enable/disable plugins
+ - `setup_globals`: **Optional** - setup vim.g globals
+ - `color_groups`: **Optional** - semantic color groups
 
 # Colors Table ~
 

--- a/lua/base16-pro-max/init.lua
+++ b/lua/base16-pro-max/init.lua
@@ -121,7 +121,7 @@ local base16_alias_map = {
 ---@mod base16-pro-max.types Types
 
 ---@class Base16ProMax.Config
----@field colors? table<Base16ProMax.Group.Raw, string> Colors to override
+---@field colors table<Base16ProMax.Group.Raw, string> Colors to override
 ---@field styles? Base16ProMax.Config.Styles Styles to override
 ---@field highlight_groups? Base16ProMax.Config.HighlightGroups.Table|Base16ProMax.Config.HighlightGroups.Function  Additional highlight groups to set
 ---@field before_highlight? fun(group: string, opts: vim.api.keyset.highlight, c: table<Base16ProMax.Group.Alias, string>): nil Callback to run before setting highlight groups
@@ -2576,13 +2576,13 @@ local default_config = {
 ---
 ---All boolean options are `false` and opt-in by default.
 ---
---- - colors: *Required* - the 16 Base 16 hex codes
---- - highlight_groups: *Optional* - additional highlight groups to set
---- - before_highlight: *Optional* - callback to run before setting highlight groups
---- - styles: *Optional* - styling options
---- - plugins: *Optional* - enable/disable plugins
---- - setup_globals: *Optional* - setup vim.g globals
---- - color_groups: *Optional* - semantic color groups
+--- - `colors`: **Required** - the 16 Base 16 hex codes
+--- - `highlight_groups`: **Optional** - additional highlight groups to set
+--- - `before_highlight`: **Optional** - callback to run before setting highlight groups
+--- - `styles`: **Optional** - styling options
+--- - `plugins`: **Optional** - enable/disable plugins
+--- - `setup_globals`: **Optional** - setup vim.g globals
+--- - `color_groups`: **Optional** - semantic color groups
 ---
 ---# Colors Table ~
 ---


### PR DESCRIPTION
Fixes #46 

Previously, the terms Required and Optional were enclosed in single asterisks and vim thinks that they correspond to tags. By enclosing them in double asterisks, the error is gone and the text is also shown in a different color (as wanted).